### PR TITLE
fix: fix github workflow and ensure merge on green on the `main` branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,6 +44,7 @@ jobs:
           KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
           KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+          KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
         options: >-
           --health-cmd "kafka-topics --bootstrap-server localhost:9092 --list"
           --health-interval 5s
@@ -62,7 +63,7 @@ jobs:
     - name: Install Protoc and dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y protobuf-compiler
+        sudo apt-get install -y protobuf-compiler netcat
         go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
         go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
         go install golang.org/x/tools/cmd/goimports@latest
@@ -74,12 +75,20 @@ jobs:
     - name: Build
       run: make build
         
-    - name: Test
+    - name: Wait for Kafka
+      run: |
+        echo "Waiting for Kafka to be ready..."
+        timeout 60s bash -c 'until nc -z localhost 9092; do sleep 1; done'
+        echo "Kafka is ready"
+        
+    - name: Run Tests
       env:
         REDIS_ADDR: localhost:6379
         KAFKA_ADDR: localhost:9092
         LOG_LEVEL: debug
         LOG_FORMAT: pretty
       run: |
-        make test-unit
-        make test-integration
+        echo "Running unit tests..."
+        go test -v -race ./pkg/...
+        echo "Running integration tests..."
+        go test -v -race ./test/integration/... -run IntegrationV2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,14 +14,41 @@ jobs:
     runs-on: ubuntu-latest
     services:
       redis:
-        image: redis:latest
+        image: redis:7-alpine
         ports:
           - 6379:6379
         options: >-
           --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 1s
+          --health-timeout 3s
+          --health-retries 30
+      zookeeper:
+        image: confluentinc/cp-zookeeper:latest
+        ports:
+          - 2181:2181
+        env:
+          ZOOKEEPER_CLIENT_PORT: 2181
+          ZOOKEEPER_TICK_TIME: 2000
+        options: >-
+          --health-cmd "echo stat | nc localhost 2181"
+          --health-interval 1s
+          --health-timeout 3s
+          --health-retries 30
+      kafka:
+        image: confluentinc/cp-kafka:latest
+        ports:
+          - 9092:9092
+        env:
+          KAFKA_BROKER_ID: 1
+          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+          KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+        options: >-
+          --health-cmd "kafka-topics --bootstrap-server localhost:9092 --list"
+          --health-interval 5s
+          --health-timeout 10s
+          --health-retries 10
 
     steps:
     - uses: actions/checkout@v4
@@ -50,6 +77,9 @@ jobs:
     - name: Test
       env:
         REDIS_ADDR: localhost:6379
+        KAFKA_ADDR: localhost:9092
+        LOG_LEVEL: debug
+        LOG_FORMAT: pretty
       run: |
         make test-unit
-        go test -v -race ./test/integration/... -run RedisIntegration
+        make test-integration


### PR DESCRIPTION
With more and more functionality adding to the repo, we will block committing on the `main` branch directly, and requires "merge on green"

First we will need to fix the current go build workflow. 